### PR TITLE
feat(to-match-screenshot): add ability to save image on comparison match

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ export default defineConfig<PlaywrightTestOptions, PlaywrightUtilsOptions>({
             maxDiffPixels: 0,
             maxDiffPixelRatio: 0,
             stopOnFirstImageDiff: false,
+            saveImageOnScreenshotMatch: true,
             animations: "disabled",
             caret: "hide",
             maskColor: "#FF00FF",
@@ -88,6 +89,7 @@ Args:
   - [maxDiffPixels][pwt-max-diff-pixels]: `number`
   - [maxDiffPixelRatio][pwt-max-diff-pixels-ratio]: `number`
   - [stopOnFirstImageDiff]: `boolean` - Stop test execution immediately after image comparison error
+  - [saveImageOnScreenshotMatch]: `boolean` - Save image on image comparison success (used by reporters)
   - [animations][pwt-animations]: `"disabled" | "allow"`
   - [caret][pwt-caret]: `"hide" | "initial"`
   - [maskColor][pwt-mask-color]: `string`

--- a/src/matchers/to-match-screenshot/handlers.test.ts
+++ b/src/matchers/to-match-screenshot/handlers.test.ts
@@ -262,10 +262,52 @@ describe("handlers", () => {
         });
     });
 
-    it("handleMatching", () => {
-        const result = handlers.handleMatching();
+    describe("handleMatching", () => {
+        [true, false].forEach(saveImage => {
+            it(`should pass with empty message if saveImageOnScreenshotMatch is '${saveImage}'`, async () => {
+                const result = await handlers.handleMatching({
+                    testInfo,
+                    saveImageOnScreenshotMatch: saveImage,
+                    expectedBuffer: Buffer.from("expected-buffer"),
+                    snapshotName: "snapshot-name",
+                    expectedPath: "expected-path",
+                });
 
-        expect(result.pass).toBe(true);
-        expect(result.message()).toBe("");
+                expect(result.pass).toBe(true);
+                expect(result.message()).toBe("");
+            });
+        });
+
+        it("should save and attach actual image if saveImageOnScreenshotMatch is 'true'", async () => {
+            await handlers.handleMatching({
+                testInfo,
+                saveImageOnScreenshotMatch: true,
+                expectedBuffer: Buffer.from("expected-buffer"),
+                snapshotName: "snapshot-name",
+                expectedPath: "expected-path",
+            });
+
+            expect(fsUtils.writeFile).toBeCalledWith("expected-path", Buffer.from("expected-buffer"));
+            expect(testInfo.attachments).toEqual([
+                {
+                    contentType: "image/png",
+                    name: "snapshot-name-expected",
+                    path: "expected-path",
+                },
+            ]);
+        });
+
+        it("should not save and attach image if saveImageOnScreenshotMatch is 'false'", async () => {
+            await handlers.handleMatching({
+                testInfo,
+                saveImageOnScreenshotMatch: false,
+                expectedBuffer: Buffer.from("expected-buffer"),
+                snapshotName: "snapshot-name",
+                expectedPath: "expected-path",
+            });
+
+            expect(fsUtils.writeFile).not.toBeCalled();
+            expect(testInfo.attachments).toEqual([]);
+        });
     });
 });

--- a/src/matchers/to-match-screenshot/handlers.ts
+++ b/src/matchers/to-match-screenshot/handlers.ts
@@ -63,6 +63,14 @@ type HandleDifferentArgs = {
     diffClusters: CoordBounds[];
 };
 
+type HandleMatchingArgs = {
+    testInfo: TestInfo;
+    saveImageOnScreenshotMatch: boolean;
+    expectedBuffer: Uint8Array;
+    snapshotName: string;
+    expectedPath: string;
+};
+
 const mkNoRefImageError = (
     message: string,
     { snapshotName }: NoRefImageErrorOpts,
@@ -219,7 +227,18 @@ export const handleDifferent = async ({
     return { pass: true, message: () => "" };
 };
 
-export const handleMatching = (): MatcherResult => {
+export const handleMatching = async ({
+    testInfo,
+    saveImageOnScreenshotMatch,
+    expectedBuffer,
+    snapshotName,
+    expectedPath,
+}: HandleMatchingArgs): Promise<MatcherResult> => {
+    if (saveImageOnScreenshotMatch) {
+        await fsUtils.writeFile(expectedPath, expectedBuffer);
+        testInfo.attachments.push(createExpectedAttachment(snapshotName, expectedPath));
+    }
+
     return { pass: true, message: () => "" };
 };
 

--- a/src/matchers/to-match-screenshot/options.test.ts
+++ b/src/matchers/to-match-screenshot/options.test.ts
@@ -13,6 +13,7 @@ describe("getOptions", () => {
             maxDiffPixels: 0,
             maxDiffPixelRatio: 0,
             stopOnFirstImageDiff: false,
+            saveImageOnScreenshotMatch: true,
         };
         screenshotOpts = {
             animations: "disabled",

--- a/src/matchers/to-match-screenshot/options.ts
+++ b/src/matchers/to-match-screenshot/options.ts
@@ -10,7 +10,11 @@ export type UserScreenshotOptions = Pick<
 
 type LooksSameCompareOptions = LooksSameOptions & { createDiffImage: true };
 type IgnoreDiffPixels = { maxDiffPixelRatio: number; maxDiffPixels: number };
-export type CompareOpts = LooksSameCompareOptions & IgnoreDiffPixels & { stopOnFirstImageDiff: boolean };
+export type CompareOpts = LooksSameCompareOptions &
+    IgnoreDiffPixels & {
+        stopOnFirstImageDiff: boolean;
+        saveImageOnScreenshotMatch: boolean;
+    };
 
 type UserCompareOption =
     | "tolerance"
@@ -18,6 +22,7 @@ type UserCompareOption =
     | "maxDiffPixels"
     | "maxDiffPixelRatio"
     | "stopOnFirstImageDiff"
+    | "saveImageOnScreenshotMatch"
     | "shouldCluster"
     | "clustersSize";
 export type UserCompareOptions = Partial<Pick<CompareOpts, UserCompareOption>>;
@@ -35,6 +40,7 @@ export const defaultOptions: Options = {
     maxDiffPixels: 0,
     maxDiffPixelRatio: 0,
     stopOnFirstImageDiff: false,
+    saveImageOnScreenshotMatch: true,
 
     // Screenshot options
     animations: "disabled",
@@ -56,6 +62,7 @@ export const getOptions = (
         "maxDiffPixels",
         "maxDiffPixelRatio",
         "stopOnFirstImageDiff",
+        "saveImageOnScreenshotMatch",
     ];
 
     const userScreenshotOptionNames: Array<keyof UserScreenshotOptions> = [

--- a/src/matchers/to-match-screenshot/toMatchScreenshotWrapped.ts
+++ b/src/matchers/to-match-screenshot/toMatchScreenshotWrapped.ts
@@ -39,7 +39,8 @@ export async function toMatchScreenshotWrapped(
     const expectedPath = getScreenshotExpectedPath(testInfo, snapshotName);
     const diffPath = getScreenshotDiffPath(testInfo, snapshotName);
 
-    const { maxDiffPixels, maxDiffPixelRatio, stopOnFirstImageDiff, ...looksSameOpts } = compareOpts;
+    const { maxDiffPixels, maxDiffPixelRatio, stopOnFirstImageDiff, saveImageOnScreenshotMatch, ...looksSameOpts } =
+        compareOpts;
 
     const hasSnapshot = await fsUtils.exists(snapshotPath);
 
@@ -75,7 +76,13 @@ export async function toMatchScreenshotWrapped(
     const looksSameResult = await looksSame(actualBuffer, expectedBuffer, compareOpts);
 
     if (areSame(looksSameResult, maxDiffPixels, maxDiffPixelRatio)) {
-        return handlers.handleMatching();
+        return handlers.handleMatching({
+            testInfo,
+            saveImageOnScreenshotMatch,
+            expectedBuffer,
+            snapshotName,
+            expectedPath,
+        });
     }
 
     if (updateSnapshots === "all") {


### PR DESCRIPTION
## Что сделано
- Добавил сохранение скриншотных картинок в случае с похожими картинками (включено по умолчанию)

## Внешний вид
### pwt-reporter
<img width="1001" alt="image" src="https://github.com/gemini-testing/playwright-utils/assets/54893992/6232de57-9d38-4710-8a22-4d117f1f6400">

### html-reporter
<img width="259" alt="image" src="https://github.com/gemini-testing/playwright-utils/assets/54893992/d87a6e33-95a1-4fea-ba55-28c81754373e">
